### PR TITLE
allocate sufficient(?) vertex buffer at renderer initialization.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,21 +8,19 @@ A sample of DirectN
 4. There should be appeared triangle. This is initial data in vertex array. (primitive is "Line list", not Triangle)
 5. (Don't forget to) ***Push [Draw Line]*** button on right pane. It start 'line add' state machine. To stop it, push [Select] button.
 6. In "line add" state machine, every mouse_press adds some vertex data (in float). The count of data is on right pane.
-7. It should add a line (means two vertecies) every "Mouse_Press - Mouse_Move- Mouse_Release" events but I cannot see them and the first triangles disappeared (I'm now checking because it should keep location previously).
-A single vertex consist of 12 float numbers. One line is 24 float numbers.
+7. It should add a line (means two vertecies) every "Mouse_Press - Mouse_Move- Mouse_Release" events.
 
 ## repro error
-- (- (It is gettit is getting rare.) Ing rare.) In "line add" state machine, iteration to add line (press mouse, move mouse and release mouse) cause access violation error.
-- does not appear added line. Once you change to another page, then return back, some white line appeas.
+- Rare (fixed?). In "line add" state machine, iteration to add line (press mouse, move mouse and release mouse) cause access violation error.
 
 ## known bug
-- even though after successful update, the added data is incorrectly appears in vertex buffer. There are is matrix unmatch. So, if it comes to visible, the line appears different position (but in normalized area, inside view volume).
+- even though after successful update, the added data is incorrectly appears in vertex buffer. (There are is matrix unmatch. Left up (0,0) is tranlated center of the screen.)
 - changing windows size does not invoke swap chain resize. Repeating resizing action fix this.
+
+## issue
+- (This is limit of DirectX, not DirectN.) In this program, a vertex contains 12 float number. (pos, nor, tex, color : 48byte) With this vertecies, the limit of dynamic vertex buffer seems about 14000 vertecies on Intel J4125 (8GB memory). A line takes 2 vertecies, then only about 7000 lines available. Need some memory operation, like that using static buffer. (aside from considering other draw primitive, buffers.)
 
 ## code
 - The renderer is located in `Renderers\Dx11Renderer.cs`. it has a `MapVertexData()` where cause memory access violation.
 - The data provider is `Model\SimpleDrawLineManager.cs`. At the top of the code has `VertexData` property which should be mapped as vertex data in renderer.
 - The current control center is `ViewModels\DirectNPageViewModel`.
-
-##### I'm ashamed to show my terrible code. I struggled to cut this out.
-Please help me the way to use dynamic vertex array correctly.


### PR DESCRIPTION
Memory access error seems stopped.
With dynamic vertex buffer, the number of vertex is too small. (about 14000) See Dx11Renderer.cs.